### PR TITLE
Relationship meta fix

### DIFF
--- a/src/Implementation/Encoding/PhpArrayToRelationshipCollectionEncoder.php
+++ b/src/Implementation/Encoding/PhpArrayToRelationshipCollectionEncoder.php
@@ -8,6 +8,8 @@ use Undabot\JsonApi\Definition\Encoding\PhpArrayToLinkCollectionEncoderInterface
 use Undabot\JsonApi\Definition\Encoding\PhpArrayToMetaEncoderInterface;
 use Undabot\JsonApi\Definition\Encoding\PhpArrayToRelationshipCollectionEncoderInterface;
 use Undabot\JsonApi\Definition\Model\Resource\Relationship\Data\RelationshipDataInterface;
+use Undabot\JsonApi\Definition\Model\Resource\Relationship\Data\ToManyRelationshipDataInterface;
+use Undabot\JsonApi\Definition\Model\Resource\Relationship\Data\ToOneRelationshipDataInterface;
 use Undabot\JsonApi\Definition\Model\Resource\Relationship\RelationshipCollectionInterface;
 use Undabot\JsonApi\Implementation\Encoding\Exception\JsonApiEncodingException;
 use Undabot\JsonApi\Implementation\Model\Resource\Relationship\Data\ToManyRelationshipData;
@@ -23,18 +25,10 @@ use Undabot\JsonApi\Util\ValidResourceLinkageAssertion;
 
 class PhpArrayToRelationshipCollectionEncoder implements PhpArrayToRelationshipCollectionEncoderInterface
 {
-    /** @var PhpArrayToMetaEncoderInterface */
-    private $phpArrayToMetaEncoder;
-
-    /** @var PhpArrayToLinkCollectionEncoderInterface */
-    private $phpArrayToLinkCollectionEncoder;
-
     public function __construct(
-        PhpArrayToMetaEncoderInterface $phpArrayToMetaEncoder,
-        PhpArrayToLinkCollectionEncoderInterface $phpArrayToLinkCollectionEncoder
+        private PhpArrayToMetaEncoderInterface $phpArrayToMetaEncoder,
+        private PhpArrayToLinkCollectionEncoderInterface $phpArrayToLinkCollectionEncoder
     ) {
-        $this->phpArrayToMetaEncoder = $phpArrayToMetaEncoder;
-        $this->phpArrayToLinkCollectionEncoder = $phpArrayToLinkCollectionEncoder;
     }
 
     /**
@@ -59,18 +53,28 @@ class PhpArrayToRelationshipCollectionEncoder implements PhpArrayToRelationshipC
     private function decodeRelationship(string $relationshipName, array $relationshipValue): Relationship
     {
         $relationshipData = null;
+        $relationshipMeta = null;
         if (true === \array_key_exists('data', $relationshipValue)) {
             $relationshipData = $this->parseRelationshipData($relationshipValue['data']);
+            if ($relationshipData instanceof ToOneRelationshipDataInterface) {
+                if (true === \array_key_exists('meta', $relationshipValue['data'])) {
+                    $relationshipMeta = $this->phpArrayToMetaEncoder->decode($relationshipValue['data']['meta']);
+                }
+            } elseif ($relationshipData instanceof ToManyRelationshipDataInterface) {
+                $relationshipMetas = [];
+                foreach ($relationshipValue['data'] as $relationshipDatum) {
+                    if (true === \array_key_exists('meta', $relationshipDatum)) {
+                        $relationshipMetas[] = $relationshipDatum['meta'];
+                    }
+                }
+
+                $relationshipMeta = $this->phpArrayToMetaEncoder->decode($relationshipMetas);
+            }
         }
 
         $relationshipLinks = null;
         if (true === \array_key_exists('links', $relationshipValue)) {
             $relationshipLinks = $this->phpArrayToLinkCollectionEncoder->encode($relationshipValue['links']);
-        }
-
-        $relationshipMeta = null;
-        if (true === \array_key_exists('meta', $relationshipValue)) {
-            $relationshipMeta = $this->phpArrayToMetaEncoder->decode($relationshipValue['meta']);
         }
 
         return new Relationship(
@@ -114,7 +118,7 @@ class PhpArrayToRelationshipCollectionEncoder implements PhpArrayToRelationshipC
         $resourceIdentifier = new ResourceIdentifier(
             $resourceLinkage['id'],
             $resourceLinkage['type'],
-            $resourceLinkage['meta'] ?? null
+            (true === \array_key_exists('meta', $resourceLinkage)) ? $this->phpArrayToMetaEncoder->decode($resourceLinkage['meta']) : null,
         );
 
         return ToOneRelationshipData::make($resourceIdentifier);
@@ -129,7 +133,7 @@ class PhpArrayToRelationshipCollectionEncoder implements PhpArrayToRelationshipC
             $resourceIdentifiers[] = new ResourceIdentifier(
                 $datum['id'],
                 $datum['type'],
-                $datum['meta'] ?? null
+                (true === \array_key_exists('meta', $datum)) ? $this->phpArrayToMetaEncoder->decode($datum['meta']) : null,
             );
         }
 

--- a/tests/Unit/Encoding/PhpArray/Encode/PhpArrayToRelationshipCollectionEncoderTest.php
+++ b/tests/Unit/Encoding/PhpArray/Encode/PhpArrayToRelationshipCollectionEncoderTest.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Undabot\JsonApi\Tests\Unit\Encoding\PhpArray\Encode;
 
 use PHPUnit\Framework\TestCase;
-use Undabot\JsonApi\Definition\Encoding\PhpArrayToLinkCollectionEncoderInterface;
-use Undabot\JsonApi\Definition\Encoding\PhpArrayToMetaEncoderInterface;
+use Undabot\JsonApi\Definition\Model\Resource\Relationship\RelationshipCollectionInterface;
 use Undabot\JsonApi\Implementation\Encoding\Exception\JsonApiEncodingException;
+use Undabot\JsonApi\Implementation\Encoding\PhpArrayToLinkCollectionEncoder;
+use Undabot\JsonApi\Implementation\Encoding\PhpArrayToMetaEncoder;
 use Undabot\JsonApi\Implementation\Encoding\PhpArrayToRelationshipCollectionEncoder;
 use Undabot\JsonApi\Implementation\Model\Resource\Relationship\Data\ToManyRelationshipData;
 use Undabot\JsonApi\Implementation\Model\Resource\Relationship\Relationship;
+use Undabot\JsonApi\Implementation\Model\Resource\ResourceIdentifier;
 
 /**
  * @internal
@@ -24,8 +26,8 @@ final class PhpArrayToRelationshipCollectionEncoderTest extends TestCase
 
     protected function setUp(): void
     {
-        $phpArrayToMetaEncoder = $this->createMock(PhpArrayToMetaEncoderInterface::class);
-        $phpArrayToLinkCollectionEncoder = $this->createMock(PhpArrayToLinkCollectionEncoderInterface::class);
+        $phpArrayToMetaEncoder = new PhpArrayToMetaEncoder();
+        $phpArrayToLinkCollectionEncoder = new PhpArrayToLinkCollectionEncoder();
 
         $this->encoder = new PhpArrayToRelationshipCollectionEncoder(
             $phpArrayToMetaEncoder,
@@ -75,20 +77,43 @@ final class PhpArrayToRelationshipCollectionEncoderTest extends TestCase
 
         $relationshipsCollection = $this->encoder->encode($validRelationshipsArray);
 
-        /** @var Relationship singleRelationship */
-        $singleRelationship = $relationshipsCollection->getRelationshipByName('fakeResourceName');
+        $this->validateRelationship($relationshipsCollection, 'fakeResourceName');
 
-        static::assertCount(1, $relationshipsCollection->getRelationships());
+        /** @var ResourceIdentifier $resourceIdentifier */
+        foreach ($relationshipsCollection->getRelationshipByName('fakeResourceName')->getData()->getData()->getResourceIdentifiers() as $resourceIdentifier) {
+            static::assertInstanceOf(ResourceIdentifier::class, $resourceIdentifier);
+            static::assertNull($resourceIdentifier->getMeta());
+        }
+    }
 
-        /** @var ToManyRelationshipData relationshipData */
-        $relationshipData = $singleRelationship->getData();
+    public function testValidRelationshipsArrayIsEncodedToRelationshipsCollectionWithMetaAttributesGiven(): void
+    {
+        $validRelationshipsArray = [
+            'fakeResourceName' => [
+                'type' => 'fakeResourceNames',
+                'data' => [
+                    ['id' => 'rand-str-Id-1', 'type' => 'fakeResourceName', 'meta' => []],
+                    ['id' => 'rand-str-Id-2', 'type' => 'fakeResourceName', 'meta' => ['foo' => 'bar']],
+                    ['id' => 'rand-str-Id-3', 'type' => 'fakeResourceName', 'meta' => ['foo' => ['bar' => 'baz']]],
+                ],
+            ],
+        ];
 
-        static::assertInstanceOf(ToManyRelationshipData::class, $relationshipData);
+        $relationshipsCollection = $this->encoder->encode($validRelationshipsArray);
 
-        /** @var ToManyRelationshipData $relationships */
-        $relationships = $singleRelationship->getData();
+        $this->validateRelationship($relationshipsCollection, 'fakeResourceName');
 
-        static::assertCount(3, $relationships->getData());
+        /** @var array<int,ResourceIdentifier> $resourceIdentifiers */
+        $resourceIdentifiers = $relationshipsCollection->getRelationshipByName('fakeResourceName')->getData()->getData()->getResourceIdentifiers();
+        $firstResourceIdentifier = $resourceIdentifiers[0] ?? null;
+        $secondResourceIdentifier = $resourceIdentifiers[1] ?? null;
+        $thirdResourceIdentifier = $resourceIdentifiers[2] ?? null;
+        static::assertInstanceOf(ResourceIdentifier::class, $firstResourceIdentifier);
+        static::assertInstanceOf(ResourceIdentifier::class, $secondResourceIdentifier);
+        static::assertInstanceOf(ResourceIdentifier::class, $thirdResourceIdentifier);
+        static::assertSame([], $firstResourceIdentifier->getMeta()->getData());
+        static::assertSame(['foo' => 'bar'], $secondResourceIdentifier->getMeta()->getData());
+        static::assertSame(['foo' => ['bar' => 'baz']], $thirdResourceIdentifier->getMeta()->getData());
     }
 
     public function testMissingRelationshipTypeRaisesException(): void
@@ -121,5 +146,23 @@ final class PhpArrayToRelationshipCollectionEncoderTest extends TestCase
         $this->expectException(JsonApiEncodingException::class);
         $this->expectExceptionMessage('Resource identifier must have key `id`');
         $this->encoder->encode($invalidRelationshipArray);
+    }
+
+    private function validateRelationship(RelationshipCollectionInterface $relationshipsCollection, string $relationshipName): void
+    {
+        /** @var Relationship $singleRelationship */
+        $singleRelationship = $relationshipsCollection->getRelationshipByName($relationshipName);
+
+        static::assertCount(1, $relationshipsCollection->getRelationships());
+
+        /** @var ToManyRelationshipData $relationshipData */
+        $relationshipData = $singleRelationship->getData();
+
+        static::assertInstanceOf(ToManyRelationshipData::class, $relationshipData);
+
+        /** @var ToManyRelationshipData $relationships */
+        $relationships = $singleRelationship->getData();
+
+        static::assertCount(3, $relationships->getData());
     }
 }


### PR DESCRIPTION
Description: 

When generating relationship resource object we were pulling meta key from entire relationships object instead from each relation one by one. Also we had issue that we pushed raw PHP array to resource identifier object instead of encoded meta interface. This is all fixed in this PR.