### PR TITLE
Allow lid in the resource

### DIFF
--- a/src/Util/ValidResourceAssertion.php
+++ b/src/Util/ValidResourceAssertion.php
@@ -20,7 +20,7 @@ final class ValidResourceAssertion
         JsonApiAssertion::keyIsset($resource, 'type', 'Resource must have key `type`');
 
         // According to the JSON:API specification, these are the only allowed keys
-        $allowedKeys = ['type', 'id', 'links', 'meta', 'attributes', 'relationships'];
+        $allowedKeys = ['type', 'id', 'lid', 'links', 'meta', 'attributes', 'relationships'];
 
         // Assert that there are only whitelisted keys present
         $disallowedKeys = array_diff(array_keys($resource), $allowedKeys);
@@ -32,10 +32,21 @@ final class ValidResourceAssertion
 
         JsonApiAssertion::string($resource['type'], 'Resource `type` must be string');
 
-        // Id is optional for resources sent in POST requests
-        if (true === \array_key_exists('id', $resource)) {
+        // id or lid are optional for resources sent in POST requests
+        $isIdIncluded = true === \array_key_exists('id', $resource);
+        $isLidIncluded = true === \array_key_exists('lid', $resource);
+        if ($isIdIncluded) {
             JsonApiAssertion::string($resource['id'], 'Resource `id` must be string');
+            // If id is included, lid can't be included
+            if ($isLidIncluded) {
+                throw new ValidationException('Resource can not have both `id` and `lid`', 0);
+            }
         }
+        // if there is no id and lid is included, it must be a string
+        if ($isLidIncluded) {
+            JsonApiAssertion::string($resource['lid'], 'Resource `lid` must be string');
+        }
+
 
         // @todo validate attributes
         // @todo validate relationships

--- a/tests/Unit/Util/Assert/ValidJsonResourceAssertionTest.php
+++ b/tests/Unit/Util/Assert/ValidJsonResourceAssertionTest.php
@@ -35,78 +35,97 @@ final class ValidJsonResourceAssertionTest extends TestCase
         ValidResourceAssertion::assert($resource);
     }
 
-    public function validResourceData()
+    public function validResourceData(): \Generator
     {
-        return [
+        yield 'Only valid id and type exists' => [
             [
-                [
-                    'id' => '1',
-                    'type' => 'x',
-                ],
+                'id' => '1',
+                'type' => 'x',
             ],
+        ];
+
+        yield 'Valid id and type exists with empty attributes and relationships' => [
             [
-                [
-                    'id' => '1',
-                    'type' => 'x',
-                    'attributes' => [],
-                    'relationships' => [],
-                ],
+                'id' => '1',
+                'type' => 'x',
+                'attributes' => [],
+                'relationships' => [],
             ],
+        ];
+
+        yield 'Valid id and type exists with empty meta and links' => [
             [
-                [
-                    'id' => '1',
-                    'type' => 'x',
-                    'meta' => [],
-                    'links' => [],
-                ],
+                'id' => '1',
+                'type' => 'x',
+                'meta' => [],
+                'links' => [],
             ],
+        ];
+
+        yield 'Valid id and type exists with empty attributes, relationships, meta and links' => [
             [
-                [
-                    'id' => '1',
-                    'type' => 'x',
-                    'attributes' => [],
-                    'relationships' => [],
-                    'meta' => [],
-                    'links' => [],
-                ],
+                'id' => '1',
+                'type' => 'x',
+                'attributes' => [],
+                'relationships' => [],
+                'meta' => [],
+                'links' => [],
+            ],
+        ];
+
+        yield 'Only valid lid and type exists' => [
+            [
+                'lid' => '1',
+                'type' => 'x',
             ],
         ];
     }
 
-    public function invalidResourceData()
+    public function invalidResourceData(): \Generator
     {
-        return [
+        yield 'Missing type' => [
             [
-                [
-                    'id' => '1',
-                ],
+                'id' => '1',
             ],
+        ];
+
+        yield 'Typo in type' => [
             [
-                [
-                    'id' => '1',
-                    'typex' => 'x',
-                    'attributes' => [],
-                    'relationships' => [],
-                ],
+                'id' => '1',
+                'typex' => 'x',
+                'attributes' => [],
+                'relationships' => [],
             ],
+        ];
+
+        yield 'Typo in id' => [
             [
-                [
-                    'idx' => '1',
-                    'type' => 'x',
-                    'meta' => [],
-                    'links' => [],
-                ],
+                'idx' => '1',
+                'type' => 'x',
+                'meta' => [],
+                'links' => [],
             ],
+        ];
+
+        yield 'Forbidden extra sent' => [
             [
-                [
-                    'id' => '1',
-                    'type' => 'x',
-                    'attributes' => [],
-                    'relationships' => [],
-                    'meta' => [],
-                    'links' => [],
-                    'extra' => [],
-                ],
+                'id' => '1',
+                'type' => 'x',
+                'attributes' => [],
+                'relationships' => [],
+                'meta' => [],
+                'links' => [],
+                'extra' => [],
+            ],
+        ];
+
+        yield 'Both lid and id sent' => [
+            [
+                'id' => '1',
+                'lid' => '2',
+                'type' => 'x',
+                'meta' => [],
+                'links' => [],
             ],
         ];
     }


### PR DESCRIPTION
See here https://jsonapi.org/format/#document-resource-object-identification.
The lid is now allowed to be passed in the resource. The lid represents the local id of the client that sent the request.